### PR TITLE
issue-122 - swapping order of kosync push/pull

### DIFF
--- a/modules/menu/patches/quick_settings.lua
+++ b/modules/menu/patches/quick_settings.lua
@@ -577,10 +577,10 @@ local function apply_quick_settings()
             visible_func = function() return hasPlugin("kosync") end,
             callback = function(touch_menu)
                 touch_menu:closeMenu()
-                UIManager:broadcastEvent(Event:new("KOSyncPushProgress"))
-                -- Pull after a short delay to let the push complete first.
+                UIManager:broadcastEvent(Event:new("KOSyncPullProgress"))
+                -- Push after a short delay to let the pull complete first.
                 UIManager:scheduleIn(1, function()
-                    UIManager:broadcastEvent(Event:new("KOSyncPullProgress"))
+                    UIManager:broadcastEvent(Event:new("KOSyncPushProgress"))
                 end)
             end,
         },


### PR DESCRIPTION
See #122 - kosync doesn't let us set behavior for push, so if that is run first it will always overwrite the value in the kosync server. This change would enable users using kosync from multiple devices to keep in sync if using zenui on any of them.