### PR TITLE
Improve key navigation for quick settings, OPDS and navbar

### DIFF
--- a/modules/filebrowser/patches/navbar.lua
+++ b/modules/filebrowser/patches/navbar.lua
@@ -1144,6 +1144,7 @@ local function apply_navbar()
         file_chooser._zen_navbar_key_patched = true
         local cls_kp = file_chooser.onKeyPress
         local cls_kr = file_chooser.onKeyRelease
+        local cls_ms = file_chooser.onMenuSelect
         local HOLD_DELAY = 0.4
         local _press_hold_fn = nil   -- scheduled hold callback (nil = not pending)
         local _press_ctx = nil       -- "navbar" or "filelist" when hold pending
@@ -1311,6 +1312,17 @@ local function apply_navbar()
             return cls_kr and cls_kr(fc, key)
         end
 
+        -- On non-touch, key-only devices (e.g Kindle 4 NT), Enter may be
+        -- delivered as the menu selection event for the still-selected book.
+        -- When our virtual navbar has focus, consume that path and activate the
+        -- focused tab instead, so the list's retained selection is not opened.
+        file_chooser.onMenuSelect = function(fc, item)
+            if _navbar_focused_idx then
+                activateNavbarTab(); return true
+            end
+            return cls_ms and cls_ms(fc, item)
+        end
+
         -- All d-pad moves dispatch as FocusMove events (args={dx,dy}), not onKeyPress.
         -- Patch onFocusMove to handle navbar focus cycling and last-row→navbar.
         local cls_fm = file_chooser.onFocusMove
@@ -1449,6 +1461,15 @@ local function apply_navbar()
             end
 
             -- Close this standalone view first
+            if tapped_id == "books" then
+                setActiveTab(tapped_id)
+                local cb = tab_callbacks[tapped_id]
+                if cb then cb() end
+                UIManager:close(menu)
+                if menu._zen_close_stack then menu._zen_close_stack() end
+                return true
+            end
+
             if menu.close_callback then
                 menu.close_callback()
             elseif menu.onClose then
@@ -1497,6 +1518,29 @@ local function apply_navbar()
         if Device:hasKeys() and not menu._zen_navbar_key_patched then
             menu._zen_navbar_key_patched = true
 
+            menu.key_events = menu.key_events or {}
+            menu.key_events.ZenNavbarFocusLeft = {
+                { "Left" },
+                event = "ZenNavbarFocusLeft",
+            }
+            menu.key_events.ZenNavbarFocusRight = {
+                { "Right" },
+                event = "ZenNavbarFocusRight",
+            }
+            menu.key_events.ZenNavbarFocusUp = {
+                { "Up" },
+                event = "ZenNavbarFocusUp",
+            }
+            menu.key_events.ZenNavbarFocusDown = {
+                { "Down" },
+                event = "ZenNavbarFocusDown",
+            }
+            menu.key_events.ZenNavbarConfirm = {
+                { "Press" },
+                { "Return" },
+                event = "ZenNavbarConfirm",
+            }
+
             local function repaintStandaloneNavbar()
                 local saved_active = active_tab
                 active_tab = view_tab_id
@@ -1526,6 +1570,14 @@ local function apply_navbar()
                 if tapped_id == view_tab_id then
                     menu.page = 1; menu:updateItems(); return
                 end
+                if tapped_id == "books" then
+                    setActiveTab(tapped_id)
+                    local cb = tab_callbacks[tapped_id]
+                    if cb then cb() end
+                    UIManager:close(menu)
+                    if menu._zen_close_stack then menu._zen_close_stack() end
+                    return
+                end
                 if menu.close_callback then menu.close_callback()
                 elseif menu.onClose then menu:onClose()
                 else UIManager:close(menu) end
@@ -1535,11 +1587,7 @@ local function apply_navbar()
                 if cb then cb() end
             end
 
-            -- D-pad moves arrive as FocusMove events, not onKeyPress.
-            local cls_sfm = menu.onFocusMove
-            menu.onFocusMove = function(m, args)
-                local dx = args and args[1] or 0
-                local dy = args and args[2] or 0
+            local function moveStandaloneNavbar(m, dx, dy)
                 local vis_tabs = getVisibleTabs()
                 local n = #vis_tabs
                 if n > 0 then
@@ -1556,12 +1604,44 @@ local function apply_navbar()
                         end
                         return true
                     end
-                    if dy == 1 and m.selected and m.layout
-                            and not m.layout[m.selected.y + 1] then
+                    if dy == 1 and (not m.selected or not m.layout
+                            or not m.layout[m.selected.y + 1]) then
                         focusStandaloneNavbar(vis_tabs)
                         repaintStandaloneNavbar(); return true
                     end
                 end
+                return false
+            end
+
+            function menu:onZenNavbarFocusLeft()
+                return moveStandaloneNavbar(self, -1, 0)
+            end
+
+            function menu:onZenNavbarFocusRight()
+                return moveStandaloneNavbar(self, 1, 0)
+            end
+
+            function menu:onZenNavbarFocusUp()
+                return moveStandaloneNavbar(self, 0, -1)
+            end
+
+            function menu:onZenNavbarFocusDown()
+                return moveStandaloneNavbar(self, 0, 1)
+            end
+
+            function menu:onZenNavbarConfirm()
+                if _navbar_focused_idx then
+                    activateStandaloneTab(); return true
+                end
+                return false
+            end
+
+            -- D-pad moves arrive as FocusMove events, not onKeyPress.
+            local cls_sfm = menu.onFocusMove
+            menu.onFocusMove = function(m, args)
+                local dx = args and args[1] or 0
+                local dy = args and args[2] or 0
+                if moveStandaloneNavbar(m, dx, dy) then return true end
                 return cls_sfm and cls_sfm(m, args)
             end
 

--- a/modules/global/patches/opds.lua
+++ b/modules/global/patches/opds.lua
@@ -33,7 +33,8 @@ local function apply_opds()
     local VGroup          = require("ui/widget/verticalgroup")
     local VSpan           = require("ui/widget/verticalspan")
     local logger          = require("logger")
-    local Screen          = require("device").screen
+    local Device          = require("device")
+    local Screen          = Device.screen
 
     -- Cover cache: [url] → { bb } | { failed = true }  (session-scoped)
     local _cover_cache = {}
@@ -753,6 +754,17 @@ local function apply_opds()
 
     -- ── Navigation buttons ───────────────────────────────────────────────────
 
+    local function activate_right_button(browser)
+        local in_catalog = #browser.paths > 0
+        if in_catalog and browser.search_url then
+            browser:searchCatalog(browser.search_url)
+        elseif browser.facet_groups then
+            browser:showFacetMenu()
+        else
+            browser:showOPDSMenu()
+        end
+    end
+
     local function fix_buttons(browser)
         if browser.title_bar then
             browser.title_bar:setLeftIcon("chevron.left")
@@ -771,15 +783,29 @@ local function apply_opds()
             local right_icon = (in_catalog and has_search) and "appbar.search" or "appbar.menu"
             browser.title_bar:setRightIcon(right_icon)
             browser.title_bar.right_button.callback = function()
-                if in_catalog and browser.search_url then
-                    browser:searchCatalog(browser.search_url)
-                elseif browser.facet_groups then
-                    browser:showFacetMenu()
-                else
-                    browser:showOPDSMenu()
-                end
+                activate_right_button(browser)
             end
         end
+
+        if Device:hasKeys() then
+            browser.key_events = browser.key_events or {}
+            -- Stock Menu binds the physical Menu key to LeftButtonTap.  Zen UI
+            -- moves OPDS navigation/back to the left button and the OPDS menu
+            -- to the right button, so override that inherited binding here.
+            browser.key_events.LeftButtonTap = {
+                { "Menu" },
+                event = "ZenOPDSMenu",
+            }
+            browser.key_events.ZenOPDSMenu = {
+                { "Menu" },
+                event = "ZenOPDSMenu",
+            }
+        end
+    end
+
+    function OPDSBrowser:onZenOPDSMenu()
+        activate_right_button(self)
+        return true
     end
 
     local orig_init = OPDSBrowser.init

--- a/modules/global/patches/opds.lua
+++ b/modules/global/patches/opds.lua
@@ -131,6 +131,35 @@ local function apply_opds()
     local PAD   = Size.padding.small
     local PAD_V = 6
 
+    local function set_focus_visual(widget, focused)
+        if not widget or not widget[1] then return end
+        local frame = widget[1]
+        frame.invert = focused and true or false
+        if frame.dimen then
+            UIManager:setDirty(nil, "ui", frame.dimen)
+        elseif widget.dimen then
+            UIManager:setDirty(nil, "ui", widget.dimen)
+        end
+    end
+
+    local function snapshot_focus(menu)
+        if menu and menu.selected then
+            return { x = menu.selected.x, y = menu.selected.y }
+        end
+    end
+
+    local function restore_focus(menu, old_selected)
+        if not menu then return end
+        if old_selected then
+            local row = menu.layout and menu.layout[old_selected.y]
+            if row and row[old_selected.x] then
+                menu:moveFocusTo(old_selected.x, old_selected.y, 0)
+                return
+            end
+        end
+        menu:moveFocusTo(1, 1, 0)
+    end
+
     local _corner_radius = Screen:scaleBySize(8)
     local _plugin = rawget(_G, "__ZEN_UI_PLUGIN")
 
@@ -268,6 +297,7 @@ local function apply_opds()
             width = self.item_w, height = self.item_h,
             bordersize = 0, padding = 0,
             background = Blitbuffer.COLOR_WHITE,
+            focusable = false,
             VGroup:new{
                 align = "left",
                 VSpan:new{ width = PAD_V },
@@ -308,6 +338,16 @@ local function apply_opds()
         self:init()
         local dimen = Geom:new{ x = x, y = y, w = self.item_w, h = self.item_h }
         UIManager:setDirty(self.show_parent, function() return "ui", dimen end)
+    end
+
+    function OPDSItem:onFocus()
+        set_focus_visual(self, true)
+        return true
+    end
+
+    function OPDSItem:onUnfocus()
+        set_focus_visual(self, false)
+        return true
     end
 
     function OPDSItem:onTapSelect()
@@ -395,8 +435,19 @@ local function apply_opds()
             width = self.cell_w, height = self.cell_h,
             bordersize = 0, padding = 0,
             background = Blitbuffer.COLOR_WHITE,
+            focusable = false,
             inner,
         }
+    end
+
+    function OPDSMosaicItem:onFocus()
+        set_focus_visual(self, true)
+        return true
+    end
+
+    function OPDSMosaicItem:onUnfocus()
+        set_focus_visual(self, false)
+        return true
     end
 
     function OPDSMosaicItem:paintTo(bb, x, y)
@@ -437,6 +488,7 @@ local function apply_opds()
         if #(self.paths or {}) == 0 then
             if self._zen_halt then self._zen_halt(); self._zen_halt = nil end
             local old_dimen = self.dimen and self.dimen:copy()
+            local old_selected = snapshot_focus(self)
             self.layout = {}
             self.item_group:clear()
             self.page_info:resetLayout()
@@ -487,6 +539,7 @@ local function apply_opds()
 
             self:updatePageInfo(select_number)
             self:mergeTitleBarIntoLayout()
+            restore_focus(self, old_selected)
             UIManager:setDirty(self.show_parent, function()
                 local rd = old_dimen and old_dimen:combine(self.dimen) or self.dimen
                 return "ui", rd
@@ -528,6 +581,7 @@ local function apply_opds()
         logger.dbg("OPDS updateItems: display_mode=", display_mode, "mosaic=", mosaic_mode)
 
         local old_dimen = self.dimen and self.dimen:copy()
+        local old_selected = snapshot_focus(self)
         self.layout = {}
         self.item_group:clear()
         self.page_info:resetLayout()
@@ -672,6 +726,7 @@ local function apply_opds()
 
         self:updatePageInfo(select_number)
         self:mergeTitleBarIntoLayout()
+        restore_focus(self, old_selected)
         UIManager:setDirty(self.show_parent, function()
             local rd = old_dimen and old_dimen:combine(self.dimen) or self.dimen
             return "ui", rd

--- a/modules/menu/patches/quick_settings.lua
+++ b/modules/menu/patches/quick_settings.lua
@@ -738,6 +738,20 @@ local function apply_quick_settings()
                     icon,
                 },
             }
+            circle.onFocus = function(self)
+                self.invert = true
+                if self.dimen then
+                    UIManager:setDirty(nil, "ui", self.dimen)
+                end
+                return true
+            end
+            circle.onUnfocus = function(self)
+                self.invert = false
+                if self.dimen then
+                    UIManager:setDirty(nil, "ui", self.dimen)
+                end
+                return true
+            end
             local label = TextWidget:new{
                 text = label_text,
                 face = label_font,
@@ -753,6 +767,7 @@ local function apply_quick_settings()
         end
 
         local top_row = HorizontalGroup:new{ align = "center" }
+        refs.button_layout_row = {}
 
         if num_buttons > 0 then
             local btn_gap = math.floor((inner_width - num_buttons * action_btn_size) / math.max(num_buttons - 1, 1))
@@ -777,6 +792,7 @@ local function apply_quick_settings()
                         def.hold_callback(touch_menu)
                     end or nil,
                 })
+                table.insert(refs.button_layout_row, btn_circle)
 
                 table.insert(top_row, btn_widget)
                 if i < num_buttons then
@@ -1015,6 +1031,11 @@ local function apply_quick_settings()
         local panel_fn = self.item_table.panel
         local panel = type(panel_fn) == "function" and panel_fn(self) or panel_fn
         table.insert(self.item_group, panel)
+
+        local qs_refs = self._qs_refs
+        if qs_refs and qs_refs.button_layout_row and #qs_refs.button_layout_row > 0 then
+            table.insert(self.layout, qs_refs.button_layout_row)
+        end
 
         -- Footer (no pagination)
         table.insert(self.item_group, self.footer_top_margin)

--- a/modules/menu/patches/quick_settings.lua
+++ b/modules/menu/patches/quick_settings.lua
@@ -1022,6 +1022,12 @@ local function apply_quick_settings()
                 self._qs_slider_locked = false
             end)
         end
+        -- Preserve keyboard focus position before clearing layout so toggle
+        -- callbacks can rebuild without jumping focus back to the tab bar.
+        local old_selected
+        if self.selected then
+            old_selected = { x = self.selected.x, y = self.selected.y }
+        end
         self.item_group:clear()
         self.layout = {}
         table.insert(self.item_group, self.bar)
@@ -1054,7 +1060,18 @@ local function apply_quick_settings()
         local old_dimen = self.dimen:copy()
         self.dimen.w = self.width
         self.dimen.h = self.item_group:getSize().h + self.bordersize * 2 + self.padding
-        self:moveFocusTo(self.cur_tab, 1, FocusManager.NOT_FOCUS)
+        -- Restore keyboard focus to the same position after rebuild; fall
+        -- back to the tab bar only if the old slot no longer exists.
+        if old_selected then
+            local row = self.layout[old_selected.y]
+            if row and row[old_selected.x] then
+                self:moveFocusTo(old_selected.x, old_selected.y, 0)
+            else
+                self:moveFocusTo(self.cur_tab, 1, FocusManager.NOT_FOCUS)
+            end
+        else
+            self:moveFocusTo(self.cur_tab, 1, FocusManager.NOT_FOCUS)
+        end
 
         local keep_bg = old_dimen and self.dimen.h >= old_dimen.h
         UIManager:setDirty((self.is_fresh or keep_bg) and self.show_parent or "all", function()


### PR DESCRIPTION
Adds some missing key-only navigation (as in non-touch devices) support.

Changes:
- Quick Settings navigation
  - preserving focus after toggles rebuild the menu
- OPDS catalog list navigation
  - there was no way without touch
  - bind the OPDS physical Menu key to the OPDS action menu
- Fix navbar key activation on non-touch devices where Enter could open the selected book instead of the focused navbar tab.
  - Allow empty standalone navbar views, such as empty Favorites, to focus, move, and activate navbar tabs with keys.

I didn't test all the configurations (list, mosaic, etc) :see_no_evil: 
