### PR TITLE
Add cover mode for highlights (highlight, underline, strikethrough, invert) for review

### DIFF
--- a/locales/zh_CN.po
+++ b/locales/zh_CN.po
@@ -1721,3 +1721,90 @@ msgstr "禅 UI 已是最新版本。"
 
 msgid "Zen UI: "
 msgstr "禅 UI: "
+
+msgid "Match whole words"
+msgstr "整词匹配"
+
+msgid "Folder name"
+msgstr "文件夹名称"
+
+msgid "Badge color: "
+msgstr "徽章颜色："
+
+msgid "Show new banner"
+msgstr "显示新书徽章"
+
+msgid "Show title below cover (mosaic)"
+msgstr "封面下方显示标题（马赛克）"
+
+msgid "Show author below cover (mosaic)"
+msgstr "封面下方显示作者（马赛克）"
+
+msgid "Opaque background"
+msgstr "不透明背景"
+
+msgid "Gallery"
+msgstr "画廊视图"
+
+msgid "First cover image"
+msgstr "第一个封面图片"
+
+msgid "Stack"
+msgstr "堆叠视图"
+
+msgid "Show spine lines"
+msgstr "显示书脊线"
+
+msgid "Show item count"
+msgstr "显示文件数量"
+
+msgid "(standard)"
+msgstr "（标准）"
+
+msgid "(Kindle)"
+msgstr "（Kindle）"
+
+msgid "Top status bar"
+msgstr "顶部状态栏"
+
+msgid "Enable top status bar"
+msgstr "开启顶部状态栏"
+
+msgid "Cover Mode"
+msgstr "遮盖模式"
+
+msgid "Enable Cover"
+msgstr "开启遮盖"
+
+msgid "Cover All / Uncover All"
+msgstr "全部遮盖 / 揭开全部"
+
+msgid "Single Cover - "
+msgstr "单个遮盖 - "
+
+msgid "Double-tap to toggle"
+msgstr "双击切换"
+
+msgid "Single-tap to toggle"
+msgstr "单击切换"
+
+msgid "Single-tap to toggle (block menu)"
+msgstr "单击切换（阻止菜单）"
+
+msgid "Single-tap to toggle (show menu)"
+msgstr "单击切换（弹出菜单）"
+
+msgid "Coverable Drawer Types"
+msgstr "可遮盖样式"
+
+msgid "Highlight"
+msgstr "高亮"
+
+msgid "Underline"
+msgstr "下划线"
+
+msgid "Strikethrough"
+msgstr "删除线"
+
+msgid "Invert"
+msgstr "反色"

--- a/modules/reader/patches/reader_covermode.lua
+++ b/modules/reader/patches/reader_covermode.lua
@@ -1,0 +1,347 @@
+-- modules/reader/patches/reader_covermode.lua
+local function apply_covermode()
+    --[[
+    Patch: Cover Mode - Add cover mode for highlights (highlight, underline, strikethrough, invert) for review
+    ]]
+
+    local Blitbuffer = require("ffi/blitbuffer")
+    local UIManager = require("ui/uimanager")
+    local Dispatcher = require("dispatcher")
+    local Event = require("ui/event")
+    local _ = require("gettext")
+
+    -- Helper function: Check if a point is inside a rectangle
+    local function inside_box(pos, box)
+        if pos then
+            local x, y = pos.x, pos.y
+            if box.x <= x and box.y <= y
+                and box.x + box.w >= x
+                and box.y + box.h >= y then
+                return true
+            end
+        end
+        return false
+    end
+
+    -- Get the actual page number of a rect (for continuous mode)
+    local function getPageFromScreenRect(self, rect)
+        if not self.page_states then
+            return self.state and self.state.page or 1
+        end
+        
+        local y = rect.y
+        local y_offset = 0
+        local gap = (self.page_gap and self.page_gap.height) or 0
+        
+        for _, state in ipairs(self.page_states) do
+            if y >= y_offset and y < y_offset + state.visible_area.h then
+                return state.page
+            end
+            y_offset = y_offset + state.visible_area.h + gap
+        end
+        
+        return self.page_states[1] and self.page_states[1].page or 1
+    end
+
+    -- Master switch
+    local function isEnabled()
+        return G_reader_settings:readSetting("cover_mode_enabled", true)
+    end
+
+    -- Toggle mode: 1 = double-tap, 2 = single-tap (no menu), 3 = single-tap (with menu)
+    local function getToggleMode()
+        return G_reader_settings:readSetting("cover_mode_toggle_mode", 1)
+    end
+
+    -- Get list of drawer types to cover
+    local function getCoveredDrawers()
+        return G_reader_settings:readSetting("cover_mode_drawers", {lighten = true})
+    end
+
+    -- Check if a specific drawer type needs covering
+    local function shouldCoverDrawer(drawer)
+        if not isEnabled() then
+            return false
+        end
+        local covered = getCoveredDrawers()
+        return covered[drawer] == true
+    end
+
+    -- Toggle cover state for a specific highlight
+    local function toggleHighlight(highlight, index)
+        if not isEnabled() then
+            return
+        end
+        highlight._temp_covered = highlight._temp_covered or {}
+        local is_covered = highlight._temp_covered[index] == true
+        highlight._temp_covered[index] = not is_covered
+        
+        local ReaderUI = require("apps/reader/readerui")
+        if ReaderUI and ReaderUI.instance then
+            -- Only mark dirty, do NOT trigger recalculate (avoid page jump in PDF paged mode)
+            UIManager:setDirty(ReaderUI.instance.dialog, "ui")
+        else
+            UIManager:setDirty(nil, "full")
+        end
+    end
+
+    local drawer_patched = false
+
+    local function patchCoverMode()
+        local ReaderHighlight = require("apps/reader/modules/readerhighlight")
+        local ReaderView = require("apps/reader/modules/readerview")
+        local ReaderUI = require("apps/reader/readerui")
+        
+        if not ReaderView then
+            return
+        end
+        
+        -- ============================================================
+        -- 1. Override drawer function - support multiple styles + PDF compatibility
+        -- ============================================================
+        if not drawer_patched then
+            local original_draw = ReaderView.drawHighlightRect
+            
+            function ReaderView.drawHighlightRect(self, bb, _x, _y, rect, drawer, color, draw_note_mark)
+                if shouldCoverDrawer(drawer) then
+                    local index = nil
+                    -- Method 1: Direct object reference matching (works for EPUB)
+                    if self.highlight.visible_boxes then
+                        for _, box in ipairs(self.highlight.visible_boxes) do
+                            if box.rect == rect then
+                                index = box.index
+                                break
+                            end
+                        end
+                    end
+                    
+                    -- Method 2: Coordinate transformation matching (required for PDF)
+                    if index == nil and self.highlight.visible_boxes then
+                        local current_page = getPageFromScreenRect(self, rect)
+                        for _, box in ipairs(self.highlight.visible_boxes) do
+                            local screen_rect = self:pageToScreenTransform(current_page, box.rect)
+                            if screen_rect and math.abs(screen_rect.x - rect.x) < 2 and math.abs(screen_rect.y - rect.y) < 2 then
+                                index = box.index
+                                break
+                            end
+                        end
+                    end
+                    
+                    local is_covered = false
+                    if index and self.ui and self.ui.highlight and self.ui.highlight._temp_covered then
+                        is_covered = self.ui.highlight._temp_covered[index] == true
+                    end
+                    
+                    local x, y, w, h = rect.x, rect.y, rect.w, rect.h
+                    
+                    if is_covered then
+                        if color then
+                            local c = Blitbuffer.ColorRGB32(color.r, color.g, color.b, 0xFF)
+                            bb:blendRectRGB32(x, y, w, h, c)
+                        else
+                            local yellow = Blitbuffer.colorFromName("yellow")
+                            if yellow then
+                                local c = Blitbuffer.ColorRGB32(yellow.r, yellow.g, yellow.b, 0xFF)
+                                bb:blendRectRGB32(x, y, w, h, c)
+                            else
+                                bb:darkenRect(x, y, w, h, 1)
+                            end
+                        end
+                        return
+                    end
+                end
+                
+                if original_draw then
+                    original_draw(self, bb, _x, _y, rect, drawer, color, draw_note_mark)
+                end
+            end
+            
+            drawer_patched = true
+        end
+        
+        -- ============================================================
+        -- 2. Register double-tap gesture (re-register on every book open)
+        -- ============================================================
+        local original_reader_ready = ReaderHighlight.onReaderReady
+        
+        function ReaderHighlight:onReaderReady()
+            if original_reader_ready then
+                original_reader_ready(self)
+            end
+
+            -- Re-register gesture on every book open to ensure double-tap works
+            self.ui:registerTouchZones({
+                {
+                    id = "readerhighlight_double_tap",
+                    ges = "double_tap",
+                    screen_zone = {
+                        ratio_x = 0, ratio_y = 0,
+                        ratio_w = 1, ratio_h = 1,
+                    },
+                    handler = function(ges)
+                        local mode = getToggleMode()
+                        if not isEnabled() or mode ~= 1 then
+                            return false
+                        end
+                        return self:onDoubleTap(ges)
+                    end,
+                    overrides = {
+                        "readerhighlight_tap",
+                        "readerhighlight_hold",
+                    },
+                },
+            })
+        end
+        
+        function ReaderHighlight:onDoubleTap(ges)
+            if not isEnabled() or getToggleMode() ~= 1 then
+                return false
+            end
+     
+            local pos = self.view:screenToPageTransform(ges.pos)
+            if not pos then
+                return false
+            end
+            
+            local tapped_index = nil
+            if self.view.highlight.visible_boxes then
+                for _, box in ipairs(self.view.highlight.visible_boxes) do
+                    if inside_box(pos, box.rect) then
+                        tapped_index = box.index
+                        break
+                    end
+                end
+            end
+            
+            if tapped_index then
+                toggleHighlight(self, tapped_index)
+                return true
+            end
+            
+            return false
+        end
+        
+        -- ============================================================
+        -- 3. Hook onTap (for single-tap modes)
+        -- ============================================================
+        local original_onTap = ReaderHighlight.onTap
+        
+        function ReaderHighlight:onTap(_, ges)
+            local mode = getToggleMode()
+            
+            -- Double-tap mode: pass through to original
+            if not isEnabled() or mode == 1 then
+                return original_onTap(self, _, ges)
+            end
+            
+            -- Single-tap modes (mode 2 or 3)
+            local pos = self.view:screenToPageTransform(ges.pos)
+            
+            local tapped_index = nil
+            if self.view.highlight.visible_boxes then
+                for _, box in ipairs(self.view.highlight.visible_boxes) do
+                    if inside_box(pos, box.rect) then
+                        tapped_index = box.index
+                        break
+                    end
+                end
+            end
+            
+           if tapped_index then
+                -- Get the annotation item to check its drawer type
+                local annotations = self.ui.annotation.annotations
+                local item = annotations and annotations[tapped_index]
+        
+                if item and shouldCoverDrawer(item.drawer) then
+                    toggleHighlight(self, tapped_index)
+                    if mode == 2 then
+                         -- Mode 2: block the original menu only for covered drawer types
+                         return true
+                      end
+                    -- Mode 3: fall through to show original menu (but toggle already applied)
+                   end
+                 -- If drawer type is not covered, just show the original menu without toggling
+               end
+            
+            return original_onTap(self, _, ges)
+        end
+        
+        -- ============================================================
+        -- 4. Batch operation functions
+        -- ============================================================
+        local function coverAllHighlights(highlight)
+            if not isEnabled() then
+                return
+            end
+            highlight._temp_covered = highlight._temp_covered or {}
+            local annotations = highlight.ui.annotation.annotations
+            for idx, item in ipairs(annotations) do
+                if item.drawer then
+                    highlight._temp_covered[idx] = true
+                end
+            end
+        end
+        
+        local function uncoverAllHighlights(highlight)
+            if not isEnabled() then
+                return
+            end
+            highlight._temp_covered = highlight._temp_covered or {}
+            local annotations = highlight.ui.annotation.annotations
+            for idx, item in ipairs(annotations) do
+                if item.drawer then
+                    highlight._temp_covered[idx] = false
+                end
+            end
+        end
+        
+        -- ============================================================
+        -- 5. Toggle function for ZenUI menu
+        -- ============================================================
+        function ReaderUI:onToggleCoverMode()
+            if not isEnabled() then
+                return
+            end
+            local highlight = self.highlight
+            if not highlight then
+                return
+            end
+            
+            local has_covered = false
+            local annotations = highlight.ui.annotation.annotations
+            for idx, item in ipairs(annotations) do
+                if item.drawer then
+                    local is_cov = highlight._temp_covered and highlight._temp_covered[idx]
+                    if is_cov then
+                        has_covered = true
+                        break
+                    end
+                end
+            end
+            
+            if has_covered then
+                uncoverAllHighlights(highlight)
+            else
+                coverAllHighlights(highlight)
+            end
+            
+            -- Force redraw
+            UIManager:setDirty(self.dialog, "ui")
+        end
+        
+        -- ============================================================
+        -- 6. Register Dispatcher gesture action
+        -- ============================================================
+        Dispatcher:registerAction("toggle_cover_mode_action", {
+            category = "none",
+            event = "ToggleCoverMode",
+            title = _("Cover all / Uncover all"),
+            reader = true,
+            ui = true,
+        })
+    end
+
+    patchCoverMode()
+end
+
+return apply_covermode

--- a/modules/reader/reader.lua
+++ b/modules/reader/reader.lua
@@ -15,6 +15,7 @@ local PATCH_MODULES = {
     highlight_menu = "modules/reader/patches/highlight_menu",
     dict_quick_lookup = "modules/reader/patches/dict_quick_lookup",
     status_on_open = "modules/reader/patches/status_on_open",
+    cover_mode = "modules/reader/patches/reader_covermode",
 }
 
 local function is_feature_enabled(plugin, key)
@@ -112,6 +113,12 @@ function M.init(logger, plugin)
         run_feature(logger, plugin, "dict_quick_lookup", dict_quick_lookup_fn)
     end
 
+    -- Always apply: cover mode
+    local cover_mode_fn = load_patch("cover_mode")
+    if cover_mode_fn then
+        run_feature(logger, plugin, "cover_mode", cover_mode_fn)
+    end
+    
     -- Always apply: custom highlight/lookup popup (self-disables when feature is off).
     local highlight_menu_fn = load_patch("highlight_menu")
     logger.dbg("zen-ui[reader]: load_patch(highlight_menu)=", tostring(highlight_menu_fn))

--- a/modules/settings/sections/reader_settings.lua
+++ b/modules/settings/sections/reader_settings.lua
@@ -390,6 +390,185 @@ function M.build(ctx)
     })
 
     -- -------------------------------------------------------------------------
+    -- Cover Mode
+    -- -------------------------------------------------------------------------
+    
+    -- Helper function: get coverable drawer types
+    local function getCoveredDrawers()
+        return G_reader_settings:readSetting("cover_mode_drawers", {lighten = true})
+    end
+    
+    -- Helper function: save coverable drawer types and refresh
+    local function saveCoveredDrawers(drawers)
+        G_reader_settings:saveSetting("cover_mode_drawers", drawers)
+        local ReaderUI = require("apps/reader/readerui")
+        if ReaderUI and ReaderUI.instance and ReaderUI.instance.view then
+            if ReaderUI.instance.view.recalculate then
+                ReaderUI.instance.view:recalculate()
+            end
+            ReaderUI.instance:handleEvent(Event:new("RedrawCurrentView"))
+            UIManager:setDirty(nil, "full")
+        end
+    end
+    
+    -- Build coverable drawer types submenu
+    local function buildDrawerSettingsSubMenu()
+        local sub_items = {}
+        local drawer_names = {
+            lighten = _("Highlight"),
+            underscore = _("Underline"),
+            strikeout = _("Strikethrough"),
+            invert = _("Invert"),
+        }
+        
+        for drawer, name in pairs(drawer_names) do
+            table.insert(sub_items, {
+                text = name,
+                checked_func = function()
+                    local covered = getCoveredDrawers()
+                    return covered[drawer] == true
+                end,
+                callback = function(touchmenu_instance)
+                    local covered = getCoveredDrawers()
+                    covered[drawer] = not covered[drawer]
+                    saveCoveredDrawers(covered)
+                    if touchmenu_instance then
+                        touchmenu_instance:updateItems()
+                    end
+                end,
+            })
+        end
+        return sub_items
+    end
+    
+    table.insert(items, {
+        text = _("Cover Mode"),
+        sub_item_table = {
+            -- Enable Cover - directly uses original setting
+            {
+                text = _("Enable Cover"),
+                checked_func = function()
+                    return G_reader_settings:readSetting("cover_mode_enabled", true)
+                end,
+                callback = function(touchmenu_instance)
+                    local new_value = not G_reader_settings:readSetting("cover_mode_enabled", true)
+                    G_reader_settings:saveSetting("cover_mode_enabled", new_value)
+                    local Notification = require("ui/widget/notification")
+                    if new_value then
+                        Notification:notify(_("Cover mode enabled"))
+                    else
+                        Notification:notify(_("Cover mode disabled"))
+                    end
+                    local ReaderUI = require("apps/reader/readerui")
+                    if ReaderUI and ReaderUI.instance then
+                        if ReaderUI.instance.view and ReaderUI.instance.view.recalculate then
+                            ReaderUI.instance.view:recalculate()
+                        end
+                        ReaderUI.instance:handleEvent(Event:new("RedrawCurrentView"))
+                        UIManager:setDirty(nil, "full")
+                    end
+                    if touchmenu_instance then
+                        touchmenu_instance:updateItems()
+                    end
+                end,
+            },
+            
+            -- Cover all / Uncover all
+            {
+                text = _("Cover All / Uncover All"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("cover_mode_enabled", true)
+                end,
+                checked_func = function()
+                    local ReaderUI = require("apps/reader/readerui")
+                    if not ReaderUI or not ReaderUI.instance then return false end
+                    local highlight = ReaderUI.instance.highlight
+                    if not highlight or not highlight._temp_covered then return false end
+                    local annotations = highlight.ui.annotation.annotations
+                    for idx, item in ipairs(annotations) do
+                        if item.drawer and highlight._temp_covered[idx] then
+                            return true
+                        end
+                    end
+                    return false
+                end,
+                callback = function()
+                    local ReaderUI = require("apps/reader/readerui")
+                    if ReaderUI and ReaderUI.instance then
+                        ReaderUI.instance:onToggleCoverMode()
+                    end
+                end,
+            },
+            
+            -- Toggle mode - displays current selection in menu text
+            {
+                text_func = function()
+                    local mode = G_reader_settings:readSetting("cover_mode_toggle_mode", 1)
+                    local mode_text = ""
+                    if mode == 1 then
+                        mode_text = _("Double-tap to toggle")
+                    elseif mode == 2 then
+                        mode_text = _("Single-tap to toggle (block menu)")
+                    else
+                        mode_text = _("Single-tap to toggle (show menu)")
+                    end
+                    return _("Single Cover - ") .. mode_text
+                end,
+                enabled_func = function()
+                    return G_reader_settings:readSetting("cover_mode_enabled", true)
+                end,
+                sub_item_table = {
+                    {
+                        text = _("Double-tap to toggle"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("cover_mode_toggle_mode", 1) == 1
+                        end,
+                        callback = function(touchmenu_instance)
+                            G_reader_settings:saveSetting("cover_mode_toggle_mode", 1)
+                            if touchmenu_instance then
+                                touchmenu_instance:updateItems()
+                            end
+                        end,
+                    },
+                    {
+                        text = _("Single-tap to toggle (block menu)"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("cover_mode_toggle_mode", 1) == 2
+                        end,
+                        callback = function(touchmenu_instance)
+                            G_reader_settings:saveSetting("cover_mode_toggle_mode", 2)
+                            if touchmenu_instance then
+                                touchmenu_instance:updateItems()
+                            end
+                        end,
+                    },
+                    {
+                        text = _("Single-tap to toggle (show menu)"),
+                        checked_func = function()
+                            return G_reader_settings:readSetting("cover_mode_toggle_mode", 1) == 3
+                        end,
+                        callback = function(touchmenu_instance)
+                            G_reader_settings:saveSetting("cover_mode_toggle_mode", 3)
+                            if touchmenu_instance then
+                                touchmenu_instance:updateItems()
+                            end
+                        end,
+                    },
+                },
+            },
+            
+            -- Coverable drawer types
+            {
+                text = _("Coverable Drawer Types"),
+                enabled_func = function()
+                    return G_reader_settings:readSetting("cover_mode_enabled", true)
+                end,
+                sub_item_table = buildDrawerSettingsSubMenu(),
+            },
+        },
+    })
+    
+    -- -------------------------------------------------------------------------
     -- Highlight / Lookup
     -- -------------------------------------------------------------------------
 


### PR DESCRIPTION
# Add covermode feature to the reader module.

Add cover mode for highlights (highlight, underline, strikethrough, invert) for review

## Files Added / Modified

| File | Operation | Description |
|:---|:---|:---|
| `modules/reader/patches/reader_covermode.lua` | Added | Core Cover Mode patch code |
| `modules/reader/reader.lua` | Modified | Added `cover_mode` to `PATCH_MODULES` and loading logic in `M.init()` |
| `modules/settings/sections/reader_settings.lua` | Modified | Added Cover Mode menu under reader settings |
| `locales/zh_CN.po` | Modified | Added Chinese translations for Cover Mode menu items |

The effect is shown in the screenshot.
<img width="1072" height="1098" alt="covermode-menu1" src="https://github.com/user-attachments/assets/43b0ea82-a1f2-44be-8208-7016150dc2a5" />
<img width="1072" height="549" alt="covermode-menu2" src="https://github.com/user-attachments/assets/699f55e9-25ad-4264-a52c-f4e6c7463af3" />
<img width="1072" height="455" alt="covermode-menu3" src="https://github.com/user-attachments/assets/d0b7773b-4d09-429e-a0c8-83a5c14944bd" />
<img width="1072" height="536" alt="covermode-menu4" src="https://github.com/user-attachments/assets/d12f83d2-6fb2-43c3-b122-ce460dfefc86" />
<img width="1072" height="1448" alt="covermode-cover" src="https://github.com/user-attachments/assets/1f597909-3074-4861-881e-26ae24a820ef" />
<img width="1072" height="1448" alt="covermode-uncover" src="https://github.com/user-attachments/assets/099da5fd-c630-4ff9-af00-3a48a513bb31" />
