### PR TITLE
fix menu crash when the background check finds a new release

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -482,15 +482,23 @@ function ZenUI:init()
         self.ui.menu:registerToMainMenu(self)
     end
 
-    -- When the background check finds a new update, reset tab_item_table on all
-    -- known menu instances so setUpdateItemTable is re-run on next menu open,
-    -- showing the update icon without requiring a restart.
-    zen_updater._on_update_found = function()
+    -- When the background check finds a new update, refresh the zen-tab icon
+    -- on every known menu instance. We update the icon in place rather than
+    -- forcing setUpdateItemTable to re-run, because KOReader's MenuSorter
+    -- mutates self.menu_items during sorting (it nils out KOMenu:menu_buttons
+    -- and every consumed leaf), so a second pass crashes in menusorter.lua at
+    -- `ipairs(menu_table["KOMenu:menu_buttons"])`. The onShowMenu patch above
+    -- also refreshes the icon, so this is just for the case where a menu
+    -- instance already exists when the background check finishes.
+    local update_icon = function()
+        local icon = zen_updater.has_update() and "zen_ui_update" or "zen_settings"
         for m_instance in pairs(_zen_menu_instances) do
-            m_instance.tab_item_table = nil
-            pcall(m_instance.setUpdateItemTable, m_instance)
+            if m_instance._zen_tab_item then
+                m_instance._zen_tab_item.icon = icon
+            end
         end
     end
+    zen_updater._on_update_found = update_icon
 
     -- Trigger background update check on fresh startup too, not only on resume.
     zen_updater.schedule_wakeup_check()


### PR DESCRIPTION
# Summary

`_on_update_found` clears `tab_item_table` and re-runs `setUpdateItemTable` on every registered menu instance to refresh the update icon. That crashes inside KOReader's `frontend/ui/menusorter.lua:139` with `bad argument #1 to 'ipairs' (table expected, got nil)`, because `MenuSorter:sort` mutates the input `item_table` while sorting — nilling every consumed leaf and finally `item_table["KOMenu:menu_buttons"]`. After the first `setUpdateItemTable` call, `self.menu_items` is empty, so the forced second pass blows up.

`pcall` hid the crash silently, but it left `tab_item_table = nil`, so the user's next attempt to open the reader menu (or file manager menu) ran `setUpdateItemTable` again on the same depleted table and crashed uncaught — kicking the user back to the launcher.

Crash signature:

```
./luajit: frontend/ui/menusorter.lua:139: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
	[C]: in function 'ipairs'
	frontend/ui/menusorter.lua:139: in function 'mergeAndSort'
	frontend/apps/reader/modules/readermenu.lua:375: in function 'orig_reader_setUpdateItemTable'
	.../zen_ui.koplugin/modules/menu/patches/quick_settings.lua:1180: in function 'orig_sut'
	plugins/zen_ui.koplugin/main.lua:408: in function 'setUpdateItemTable'
	frontend/apps/reader/modules/readermenu.lua:417: in function 'onShowMenu'
```

# Fix

Update the icon in place on the cached `_zen_tab_item` instead of forcing a rebuild. The existing `onShowMenu` patch already refreshes the icon lazily on every menu open, so this callback only matters for the edge case where a menu instance has already been opened when the background check finishes — and there, rewriting the `icon` field is enough.

# Reproduction

You'll need a device running a Zen UI version older than the latest release (so the network check returns `has_update=true`) and SSH access.

In one terminal, start tailing the log and keep it running for the entire test — every event below lands here:

```sh
ssh -p 2222 root@KINDLE_IP 'tail -F /mnt/us/koreader/crash.log'
```

Then, in a second terminal / on the device:

1. Exit KOReader cleanly on the device so it flushes settings to disk.

2. From the dev host, zero out the 24h update-check throttle so the next KOReader start runs the background check immediately:

   ```sh
   ssh -p 2222 root@KINDLE_IP \
     'sed -i "s/\[\"zen_ui_last_update_check\"\] = [0-9]*,/[\"zen_ui_last_update_check\"] = 0,/" \
      /mnt/us/koreader/settings.reader.lua'
   ```

3. Relaunch KOReader on the device and open a book.

4. **Within ~15 seconds of relaunch**, tap the top of the screen to open the reader menu, then dismiss it. This is the call to `setUpdateItemTable` that registers the `ReaderMenu` instance in `_zen_menu_instances` and (as a side effect of `MenuSorter:sort`) empties `self.menu_items`.

5. Watch the tail. About 15 seconds after KOReader's init, you'll see:

   ```
   ZenUpdater: starting background network check
   ZenUpdater: background check done, has_update= true
   WARN  menu id not found: navi
   WARN  menu id not found: typeset
   WARN  menu id not found: search
   WARN  menu id not found: filemanager
   WARN  menu id not found: setting
   WARN  menu id not found: main
   WARN  menu id not found: tools
   WARN  menu id not found: KOMenu:menu_buttons
   ```

   That flood of "menu id not found" warnings is the silent pcall-swallowed crash on the registered menu instance. After it runs, `tab_item_table` is `nil`.

6. Tap the top of the screen again. The tail shows the same warnings followed by the uncaught `menusorter.lua:139` stack above, and KOReader restarts.

The timing matters: step 4 must happen before step 5, so the menu instance is registered when `_on_update_found` fires. If you tap after the check has run, `_zen_menu_instances` is empty, the silent crash never sets up, and the menu opens normally — which is what masked this bug from showing up consistently in normal use.

# Verification

With the patch applied, repeat the same procedure with the same log tail open. After `background check done, has_update= true` you should see... nothing — no "menu id not found" warnings, no silent crash. Step 6 opens the reader menu normally, and the Zen UI tab now displays the "update available" icon (`zen_ui_update`) just as the rebuild used to produce.

