### PR TITLE
Automatically catch newly added files as "to be read"

### DIFF
--- a/common/db_bookinfo.lua
+++ b/common/db_bookinfo.lua
@@ -280,16 +280,29 @@ function M.getTBRBooks()
     local ok_ds, DocSettings = pcall(require, "docsettings")
     if not ok_ds then return {} end
 
+    -- Checks if file is a book.
+    -- Should add other filetypee - these are just the ones I use privately
+    local function isBookFile(filepath)
+        if not filepath then return false end
+        local ext = filepath:match("^.+%.([^%.]+)$")
+        if not ext then return false end
+        ext = ext:lower()
+        return ext == "epub" or ext == "mobi" or ext == "azw3"
+    end
+
     local result = {}
     for _, filepath in ipairs(candidates) do
         if DocSettings:hasSidecarFile(filepath) then
             local ok3, doc = pcall(DocSettings.open, DocSettings, filepath)
             if ok3 and doc then
                 local summary = doc:readSetting("summary")
-                if summary and summary.status == "abandoned" then
+                if summary and (summary.status == "abandoned" or summary.status == "new" or summary.status == nil) then
                     table.insert(result, filepath)
                 end
             end
+        -- Catches newly added books, without .sdr files
+        elseif (not DocSettings:hasSidecarFile(filepath)) and (isBookFile(filepath)) then
+            table.insert(result, filepath)
         end
     end
 


### PR DESCRIPTION
Updated the the TBR function to automatically catch newly-added books - books that are yes without sidecar files and to also include books with manually-added statuses of "new" or nil, if for some reason the sir file got corrupted/edited.

Added a function to check if a file is a book type (epub, mobi, azw3) in order to exclude unnecessary files from the TBR logic (like author or series images).

Please note: this worked up to beta-24 I think. With the changes to how the database is called in the newest beta (v30), this fix doesn't catch newly added book files. What is even worse, removing the filetype check (isFileBook() condition) catches jpegs that are in the Library home folder, but which weren't open and don't have corresponding sidecar files. I have no idea why that is.