### PR TITLE
Fix center_max_w calculation to prevent zero width

### DIFF
--- a/modules/filebrowser/patches/status_bar.lua
+++ b/modules/filebrowser/patches/status_bar.lua
@@ -606,7 +606,7 @@ local function apply_status_bar()
         -- then double it for the full available span.
         local left_w = left_group:getSize().w
         local half_avail = math.floor(screen_w / 2) - math.max(left_w, right_w)
-        local center_max_w = math.max(0, half_avail * 2)
+        local center_max_w = math.max(1, half_avail * 2)
 
         -- Center: nav_title override > folder name when in subfolder > configured center items
         local center_content
@@ -826,7 +826,7 @@ local function apply_status_bar()
         local left_w  = left_group:getSize().w
         local right_w = h_padding + (right_content and right_content:getSize().w or 0)
         local half_avail = math.floor(screen_w / 2) - math.max(left_w, right_w)
-        local center_max_w = math.max(0, half_avail * 2)
+        local center_max_w = math.max(1, half_avail * 2)
 
         local center_content
         if title then


### PR DESCRIPTION
Ensure center_max_w is at least 1 to avoid zero width.

```log
/usr/lib/koreader/luajit: frontend/ui/widget/textwidget.lua:224: bad argument #2 to 'makeLine' (width must be strictly positive)
stack traceback:
        [C]: in function 'makeLine'
        frontend/ui/widget/textwidget.lua:224: in function '_measureWithXText'
        frontend/ui/widget/textwidget.lua:131: in function 'updateSize'
        frontend/ui/widget/textwidget.lua:293: in function 'getSize'
        ...n_ui.koplugin/modules/filebrowser/patches/status_bar.lua:574: in function 'updateRowHeight'
        ...n_ui.koplugin/modules/filebrowser/patches/status_bar.lua:621: in function 'createStatusRow'
        ...n_ui.koplugin/modules/filebrowser/patches/status_bar.lua:988: in function '_updateStatusBar'
        ...n_ui.koplugin/modules/filebrowser/patches/status_bar.lua:1218: in function 'handleEvent'
        frontend/ui/widget/filechooser.lua:363: in function 'changeToPath'
        frontend/ui/widget/filechooser.lua:406: in function 'orig_select'
        ...es/filebrowser/patches/menu_single_page_scroll_guard.lua:40: in function 'cls_ms'
        ...
        frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
        frontend/ui/widget/container/widgetcontainer.lua:83: in function 'propagateEvent'
        frontend/ui/widget/container/widgetcontainer.lua:101: in function 'handleEvent'
        frontend/ui/uimanager.lua:910: in function 'sendEvent'
        frontend/ui/uimanager.lua:53: in function '__default__'
        frontend/ui/uimanager.lua:1441: in function 'handleInputEvent'
        frontend/ui/uimanager.lua:1541: in function 'handleInput'
        frontend/ui/uimanager.lua:1585: in function 'run'
        ./reader.lua:301: in main chunk
        [C]: at 0x556da11613b0
```