### PR TITLE
Control row breaks in Launcher

### DIFF
--- a/common/dispatch_action.lua
+++ b/common/dispatch_action.lua
@@ -212,6 +212,22 @@ local function set_bottom_status_bar(plugin, enabled)
     return true
 end
 
+-- Combines KOReader's built-in pull-then-push progress sync (previously the
+-- "Sync" quick settings button) into a single bindable action.
+local function sync_reading_progress()
+    local NetworkMgr = require("ui/network/manager")
+    local UIManager = require("ui/uimanager")
+    local Event = require("ui/event")
+    NetworkMgr:runWhenOnline(function()
+        UIManager:broadcastEvent(Event:new("KOSyncPullProgress"))
+        -- Push after a short delay to let the pull complete first.
+        UIManager:scheduleIn(1, function()
+            UIManager:broadcastEvent(Event:new("KOSyncPushProgress"))
+        end)
+    end)
+    return true
+end
+
 local _folder_picker_patched = false
 
 -- Render a per-action folder picker for zen_ui_show_folder. The default Dispatcher
@@ -353,6 +369,12 @@ function M.onDispatcherRegisterActions()
         toggle = {},
         zen_folder_picker = true,
     })
+    Dispatcher:registerAction("zen_ui_kosync_sync", {
+        category = "none",
+        event = "ZenUIKOSyncSync",
+        title = _("Zen UI - Sync progress (pull + push)"),
+        general = true,
+    })
     patch_folder_picker_menu(Dispatcher)
 end
 
@@ -423,6 +445,10 @@ function M.onShowZenUIFolder(plugin, folder)
     return show_zen_folder(plugin, folder)
 end
 
+function M.onZenUIKOSyncSync()
+    return sync_reading_progress()
+end
+
 function M.install(target)
     target.onDispatcherRegisterActions = M.onDispatcherRegisterActions
     target.onToggleZenMode = M.onToggleZenMode
@@ -436,6 +462,7 @@ function M.install(target)
     target.onShowZenUISeries = M.onShowZenUISeries
     target.onShowZenUITags = M.onShowZenUITags
     target.onShowZenUIFolder = M.onShowZenUIFolder
+    target.onZenUIKOSyncSync = M.onZenUIKOSyncSync
 end
 
 return M

--- a/modules/menu/app_launcher/model.lua
+++ b/modules/menu/app_launcher/model.lua
@@ -13,6 +13,9 @@ local function valid_entry(entry, allow_folder)
     if type(entry) ~= "table" or type(entry.id) ~= "string" then
         return false
     end
+    if entry.type == "break" then
+        return true
+    end
     if type(entry.label) ~= "string" or entry.label == "" then
         return false
     end
@@ -135,6 +138,7 @@ end
 
 function M.display_label(entry)
     if not entry then return _("App") end
+    if entry.type == "break" then return "\u{2014} " .. _("Row break") .. " \u{2014}" end
     return entry.label or _("App")
 end
 

--- a/modules/menu/patches/app_launcher.lua
+++ b/modules/menu/patches/app_launcher.lua
@@ -1,4 +1,4 @@
-local function apply_app_launcher()
+        local function apply_app_launcher()
     local Blitbuffer = require("ffi/blitbuffer")
     local CenterContainer = require("ui/widget/container/centercontainer")
     local Device = require("device")
@@ -371,6 +371,35 @@ local function apply_app_launcher()
             end
         end
 
+        -- Group visible entries into rows, honoring row-break marker entries
+        -- as well as the column count. A break entry doesn't render a cell
+        -- itself -- it just forces the next entry to start a new row.
+        local all_rows = {}
+        do
+            local current_row
+            local force_break = false
+            for _i, entry in ipairs(visible) do
+                if entry.type == "break" then
+                    force_break = true
+                else
+                    if not current_row or #current_row >= cols or force_break then
+                        current_row = {}
+                        all_rows[#all_rows + 1] = current_row
+                    end
+                    current_row[#current_row + 1] = entry
+                    force_break = false
+                end
+            end
+        end
+
+        -- Size every cell off the longest row (across all pages) so a short,
+        -- forced-break row doesn't stretch its icons wider than a full row.
+        local max_row_len = 0
+        for _i, row in ipairs(all_rows) do
+            if #row > max_row_len then max_row_len = #row end
+        end
+        local uniform_cell_w = math.floor(inner_w / math.max(1, max_row_len))
+
         -- Pagination: slice the grid so it never overflows the space a normal
         -- menu would use (bar + items area + footer). The footer up arrow then
         -- always stays on screen, matching KOReader's stock menu height.
@@ -384,8 +413,7 @@ local function apply_app_launcher()
         local footer_margin_h = (touch_menu.footer_top_margin and touch_menu.footer_top_margin:getSize().h) or 0
         local items_height = menu_height - bar_h - footer_h - footer_margin_h - pad * 2
         local rows_per_page = math.max(1, math.floor(items_height / cell_total_h) - 1)
-        local per_page = rows_per_page * cols
-        local page_num = math.max(1, math.ceil(#visible / per_page))
+        local page_num = math.max(1, math.ceil(#all_rows / rows_per_page))
         local page = touch_menu._app_launcher_page or 1
         if page > page_num then page = page_num end
         if page < 1 then page = 1 end
@@ -393,12 +421,12 @@ local function apply_app_launcher()
         refs.page = page
         refs.page_num = page_num
 
-        local page_items = {}
-        if #visible > 0 then
-            local start_idx = (page - 1) * per_page + 1
-            local end_idx = math.min(start_idx + per_page - 1, #visible)
+        local page_rows = {}
+        if #all_rows > 0 then
+            local start_idx = (page - 1) * rows_per_page + 1
+            local end_idx = math.min(start_idx + rows_per_page - 1, #all_rows)
             for i = start_idx, end_idx do
-                page_items[#page_items + 1] = visible[i]
+                page_rows[#page_rows + 1] = all_rows[i]
             end
         end
 
@@ -445,48 +473,45 @@ local function apply_app_launcher()
             VerticalSpan:new{ width = pad },
         }
 
-        for i, entry in ipairs(page_items) do
-            local col = ((i - 1) % cols) + 1
-            if col == 1 then
-                rows[#rows + 1] = HorizontalGroup:new{ align = "top" }
-                row_counts[#rows] = 0
-                local remaining = #page_items - i + 1
-                local row_count = math.min(cols, remaining)
-                row_widths[#rows] = math.floor(inner_w / row_count)
-                layout_rows[#layout_rows + 1] = {}
+        for _i, row_entries in ipairs(page_rows) do
+            rows[#rows + 1] = HorizontalGroup:new{ align = "top" }
+            row_counts[#rows] = 0
+            row_widths[#rows] = uniform_cell_w
+            layout_rows[#layout_rows + 1] = {}
+            for _j, entry in ipairs(row_entries) do
+                row_counts[#rows] = row_counts[#rows] + 1
+                local dim = not entry._app_back and not entry_available(entry, touch_menu, cfg)
+                local cell = make_cell{
+                    cell_w = row_widths[#rows] or cell_w,
+                    cell_h = cell_h,
+                    pad = pad,
+                    icon_size = icon_size,
+                    circle_size = circle_size,
+                    circle_border = circle_border,
+                    label_face = label_face,
+                    label = Model.display_label(entry),
+                    show_label = show_labels,
+                    icon = entry.icon or (entry.type == "folder" and DEFAULT_FOLDER_ICON or DEFAULT_ENTRY_ICON),
+                    dim = dim,
+                    callback = not dim and function()
+                        activate_entry(touch_menu, entry)
+                    end or nil,
+                }
+                rows[#rows][#rows[#rows] + 1] = cell
+                layout_rows[#layout_rows][#layout_rows[#layout_rows] + 1] = cell
+                refs.buttons[#refs.buttons + 1] = {
+                    widget = cell,
+                    callback = cell.callback and function()
+                        cell.callback()
+                    end or nil,
+                }
             end
-            row_counts[#rows] = row_counts[#rows] + 1
-            local dim = not entry._app_back and not entry_available(entry, touch_menu, cfg)
-            local cell = make_cell{
-                cell_w = row_widths[#rows] or cell_w,
-                cell_h = cell_h,
-                pad = pad,
-                icon_size = icon_size,
-                circle_size = circle_size,
-                circle_border = circle_border,
-                label_face = label_face,
-                label = Model.display_label(entry),
-                show_label = show_labels,
-                icon = entry.icon or (entry.type == "folder" and DEFAULT_FOLDER_ICON or DEFAULT_ENTRY_ICON),
-                dim = dim,
-                callback = not dim and function()
-                    activate_entry(touch_menu, entry)
-                end or nil,
-            }
-            rows[#rows][#rows[#rows] + 1] = cell
-            layout_rows[#layout_rows][#layout_rows[#layout_rows] + 1] = cell
-            refs.buttons[#refs.buttons + 1] = {
-                widget = cell,
-                callback = cell.callback and function()
-                    cell.callback()
-                end or nil,
-            }
         end
 
         for _i, row in ipairs(rows) do
             local used = (row_counts[_i] or 0) * (row_widths[_i] or cell_w)
-            local lead = pad
-            local trail = panel_width - pad - used
+            local lead = math.max(pad, math.floor((panel_width - used) / 2))
+            local trail = panel_width - used - lead
             table.insert(row, 1, HorizontalSpan:new{ width = lead })
             row[#row + 1] = HorizontalSpan:new{ width = math.max(0, trail) }
             panel[#panel + 1] = row

--- a/modules/menu/patches/quick_settings.lua
+++ b/modules/menu/patches/quick_settings.lua
@@ -674,13 +674,9 @@ local function apply_quick_settings()
             visible_func = function() return hasPlugin("kosync") end,
             callback = function(touch_menu)
                 touch_menu:closeMenu()
-                NetworkMgr:runWhenOnline(function()
-                    UIManager:broadcastEvent(Event:new("KOSyncPullProgress"))
-                    -- Push after a short delay to let the pull complete first.
-                    UIManager:scheduleIn(1, function()
-                        UIManager:broadcastEvent(Event:new("KOSyncPushProgress"))
-                    end)
-                end)
+                if zen_plugin.onZenUIKOSyncSync then
+                    zen_plugin:onZenUIKOSyncSync()
+                end
             end,
         },
         filebrowser = {

--- a/modules/settings/sections/app_launcher_settings.lua
+++ b/modules/settings/sections/app_launcher_settings.lua
@@ -411,6 +411,18 @@ function M.build(ctx)
                 callback = add_folder,
             }, icons.new_folder)
         end
+        items[#items + 1] = IconItem.decorate({
+            text = _("Row break"),
+            keep_menu_open = true,
+            callback = function(touch_menu)
+                local entry = {
+                    id = Model.next_id(cfg),
+                    type = "break",
+                }
+                insert_entry(entry, folder)
+                if touch_menu then touch_menu:backToUpperMenu() end
+            end,
+        }, icons.move)
         return items
     end
 
@@ -540,6 +552,8 @@ function M.build(ctx)
             for _i, item in ipairs(add_sub) do
                 items[#items + 1] = item
             end
+        elseif entry.type == "break" then
+            -- no icon/label controls; this entry is just a row-break marker
         else
             items[#items + 1] = IconItem.decorate({
                 text_func = function()
@@ -575,7 +589,9 @@ function M.build(ctx)
                 end
                 UIManager:show(ConfirmBox:new{
                     text = entry.type == "folder" and entry.children and #entry.children > 0
-                        and _("Delete this folder and its buttons?") or _("Delete this button?"),
+                            and _("Delete this folder and its buttons?")
+                        or entry.type == "break" and _("Delete this row break?")
+                        or _("Delete this button?"),
                     ok_text = _("Delete"),
                     ok_callback = remove,
                 })


### PR DESCRIPTION
Add ability for the user to control where icons start a new row in the Launcher

 - Adds a new item type "Row break" in the Buttons / Add menu.
 - The Row break appears in the Buttons list and can be re-ordered or deleted similarly to actual buttons.

This also makes the visual appearance of the Launcher more consistent by ensuring all rows have the same spacing.