### PR TITLE
Set home icon to match navbar default tab

### DIFF
--- a/common/inject_icons.lua
+++ b/common/inject_icons.lua
@@ -17,6 +17,17 @@ if _plugin_root then
         ["app_launcher"]        = "app_launcher.svg",
         ["lightning"]           = "lightning.svg",
         ["folder_open"]         = "folder_open.svg",
+        -- Navbar tab icons (needed so the menu-bar shortcut icon, which tracks
+        -- the navbar's default tab, can resolve any of them by name).
+        ["home"]                = "home.svg",
+        ["tab_manga"]           = "tab_manga.svg",
+        ["tab_news"]            = "tab_news.svg",
+        ["tab_history"]         = "tab_history.svg",
+        ["tab_collections"]     = "tab_collections.svg",
+        ["tab_authors"]         = "tab_authors.svg",
+        ["tab_series"]          = "tab_series.svg",
+        ["tab_tags"]            = "tab_tags.svg",
+        ["tab_to_be_read"]      = "tab_to_be_read.svg",
         -- Highlight / lookup popup (shared by highlight_menu + dict_quick_lookup)
         ["lookup.highlight"]    = "lookup_highlight.svg",
         ["lookup.ai"]           = "lookup_ai.svg",

--- a/main.lua
+++ b/main.lua
@@ -492,6 +492,13 @@ function ZenUI:init()
     end
 
     local function library_home_icon()
+        local get_default_tab_icon = rawget(_G, "__ZEN_UI_NAVBAR_DEFAULT_TAB_ICON")
+        if type(get_default_tab_icon) == "function" then
+            local icon = get_default_tab_icon()
+            if type(icon) == "string" and icon ~= "" then
+                return icon
+            end
+        end
         local _cfg = _zen_plugin_ref and _zen_plugin_ref.config
         local _menu = _cfg and _cfg.menu
         local icon = type(_menu) == "table" and _menu.library_home_icon

--- a/modules/filebrowser/patches/navbar.lua
+++ b/modules/filebrowser/patches/navbar.lua
@@ -2721,6 +2721,10 @@ local function apply_navbar()
     _G.__ZEN_UI_NAVBAR_OPEN_DEFAULT_TAB = open_default_tab
     _G.__ZEN_UI_NAVBAR_OPEN_TAB = open_tab
     _G.__ZEN_UI_NAVBAR_RESOLVE_DEFAULT_TAB = resolve_default_tab
+    _G.__ZEN_UI_NAVBAR_DEFAULT_TAB_ICON = function()
+        local tab = tabs_by_id[resolve_default_tab()]
+        return tab and tab.icon
+    end
 
     _G.__ZEN_UI_REINJECT_FM_NAVBAR = function()
         local fm = FileManager.instance


### PR DESCRIPTION
This sets the home icon at the right of the main menu to match whatever tab is set as the default for the navbar.

I think it is more consistent to show the icon of the tab that this button actually navigates to, rather than always showing the Library icon.

Examples:
<img width="422" height="66" alt="image" src="https://github.com/user-attachments/assets/477b8334-20f5-4bd4-a057-49492963b5cf" />

<img width="416" height="66" alt="image" src="https://github.com/user-attachments/assets/3fe34862-2a5f-4c46-822d-da254668c37d" />

<img width="408" height="62" alt="image" src="https://github.com/user-attachments/assets/97d3a97c-b2ed-4354-8223-fd48282bd099" />




