### PR TITLE
Fix AI Assistant lookup word

### DIFF
--- a/modules/reader/patches/dict_quick_lookup.lua
+++ b/modules/reader/patches/dict_quick_lookup.lua
@@ -80,8 +80,7 @@ local function apply()
                 local NetworkMgr = require("ui/network/manager")
                 NetworkMgr:runWhenOnline(function()
                     UIManager:nextTick(function()
-                        assistant.assistant_dialog:show(
-                            dict_widget.lookupword or dict_widget.word)
+                        assistant.assistant_dialog:show(dict_widget.word)
                     end)
                 end)
             end,


### PR DESCRIPTION
The AI Assistant integration currently uses `dict_widget.lookupword` - the word whose definition is displayed in the popup - as the input parameter passed to the assistant.

This seems to follow the existing pattern for VocabBuilder but doesn't work so well for AI Assistant. If the highlighted word is not a standard English term - such as the name of a character - the word chosen will typically be an unrelated word that happens to be the closest fuzzy match. For example, the novel I'm currently reading has a character named "Kelsier" and the dictionary happens to match this to "Elster" (a Pleistocene glaciation in northern Europe). The X-Ray results for "Elster" aren't particularly helpful ;).

AI Assistant should use the highlighted word (`dict_widget.word`). Using the displayed definition probably makes more sense for VocabBuilder, so I've left that part as-is.