### PR TITLE
Make OPDS "Downloaded" dialog dismissable

### DIFF
--- a/modules/global/patches/opds.lua
+++ b/modules/global/patches/opds.lua
@@ -1337,8 +1337,13 @@ local function apply_opds()
                 end,
                 ok_text      = "\u{F012C}  " .. _("Done"),
                 ok_callback  = function() end,
-                dismissable  = false,
             }
+            -- Tapping outside (or Back) should just dismiss the dialog,
+            -- not trigger the "Read now" cancel_callback.
+            function dlg:onClose()
+                UIManager:close(self)
+                return true
+            end
             UIManager:nextTick(function() UIManager:show(dlg) end)
         end
 


### PR DESCRIPTION
Allow the OPDS "Downloaded / Read now / Done" dialog box to be closed (without opening the book) by tapping outside it. This makes its behaviour more consistent with most other dialog boxes.