### PR TITLE
Top status bar for PDFs and CBZs

### DIFF
--- a/config/defaults.lua
+++ b/config/defaults.lua
@@ -219,6 +219,7 @@ local defaults = {
         custom_text      = "",
         show_bottom_border = false,
         bottom_border_progress = false,
+        hide_in_cbz = true,
     },
     reader_footer = {
         verbose_chapter_time = false,

--- a/modules/reader/patches/reader_top_status_bar.lua
+++ b/modules/reader/patches/reader_top_status_bar.lua
@@ -649,7 +649,8 @@ local function apply_reader_top_status_bar()
         _ReaderView_paintTo_orig(self, bb, x, y)
         if not is_enabled() then return end
         if bb ~= Screen.bb then return end -- offscreen renders, e.g. page-browser thumbnails
-        if self.render_mode ~= nil then return end -- pdf-like; skip
+        local cfg2 = zen_plugin and zen_plugin.config and zen_plugin.config.reader_top_status_bar
+        if self.render_mode ~= nil and (not type(cfg2) == "table" or cfg2.hide_in_cbz) then return end -- pdf-like; skip
         if not self.document then return end
         -- Guard: don't paint when reader is not active (allow overlays that
         -- belong to this ReaderUI via show_parent, e.g., AutoDim on resume).
@@ -665,7 +666,6 @@ local function apply_reader_top_status_bar()
 
         header:paintTo(bb, x, y)
 
-        local cfg2 = zen_plugin and zen_plugin.config and zen_plugin.config.reader_top_status_bar
         if type(cfg2) == "table" and cfg2.show_bottom_border then
             paintBottomBorder(bb, x, y + header_h, screen_width, cfg2, self)
             header_h = header_h + Size.line.medium

--- a/modules/settings/sections/reader_settings.lua
+++ b/modules/settings/sections/reader_settings.lua
@@ -382,6 +382,18 @@ function M.build(ctx)
                     save_clock()
                 end,
             },
+            {
+                text = _("Hide in CBZ/PDF files"),
+                checked_func = function()
+                    return type(config.reader_top_status_bar) == "table"
+                        and config.reader_top_status_bar.hide_in_cbz == true
+                end,
+                callback = function()
+                    if type(config.reader_top_status_bar) ~= "table" then config.reader_top_status_bar = {} end
+                    config.reader_top_status_bar.hide_in_cbz = not config.reader_top_status_bar.hide_in_cbz
+                    save_clock()
+                end,
+            },
         },
     })
 


### PR DESCRIPTION
the top status bar appears when an epub file is opened, but not when a PDF is opened

this also happens with the bottom status bar by default, but it has an option to disable it ("Hide in CBZ/PDF files")

I've added the same option for the top status bar too
