### PR TITLE
Add optional archive browsing integration

### DIFF
--- a/common/paths.lua
+++ b/common/paths.lua
@@ -26,6 +26,26 @@ function M.getHomeDir()
     return nil
 end
 
+-- Returns the archive root configured by the Move to Archive user patch.
+-- Archive is intentionally separate from the library roots: it can share the
+-- Zen browser presentation without feeding archived books back into Home
+-- widgets, library statistics, or library database scans.
+function M.getArchiveDir()
+    local ok_storage, DataStorage = pcall(require, "datastorage")
+    if not ok_storage or not DataStorage then return nil end
+    local path = DataStorage:getSettingsDir() .. "/move_to_archive_settings.lua"
+    local ok_settings, archive_settings = pcall(dofile, path)
+    local dir = ok_settings and type(archive_settings) == "table"
+        and archive_settings.archive_dir or nil
+    if type(dir) ~= "string" or dir == "" then return nil end
+    return M.normPath(dir:gsub("/*$", ""))
+end
+
+local function is_at_or_below(path, root)
+    return root ~= nil
+        and (path == root or path:sub(1, #root + 1) == root .. "/")
+end
+
 function M.isUnsafeFlatViewRoot(path)
     if type(path) ~= "string" then return false end
     local norm = M.normPath(path:gsub("/*$", ""))
@@ -102,6 +122,15 @@ function M.isInHomeDir(path)
     end
 
     return false
+end
+
+-- Browser presentation scope: normal library roots plus the external archive
+-- configured by the Move to Archive patch.
+function M.isInThemedDir(path)
+    if M.isInHomeDir(path) then return true end
+    if not path then return false end
+    local norm = M.normPath(path:gsub("/+$", ""))
+    return is_at_or_below(norm, M.getArchiveDir())
 end
 
 function M.getHomeLockMode()

--- a/config/defaults.lua
+++ b/config/defaults.lua
@@ -73,6 +73,7 @@ local defaults = {
     navbar = {
         show_tabs = {
             books = true,
+            archive = false,
             manga = false,
             news = false,
             continue = true,

--- a/locales/en.po
+++ b/locales/en.po
@@ -2525,3 +2525,9 @@ msgstr "Delete this custom theme?"
 
 msgid "Custom theme"
 msgstr "Custom theme"
+
+msgid "Archive"
+msgstr "Archive"
+
+msgid "Archive folder not found: "
+msgstr "Archive folder not found: "

--- a/modules/filebrowser/patches/browser_display_mode_by_path.lua
+++ b/modules/filebrowser/patches/browser_display_mode_by_path.lua
@@ -47,7 +47,7 @@ local function apply_browser_display_mode_by_path()
     end
 
     local function is_in_home(path)
-        return paths.isInHomeDir(path)
+        return paths.isInThemedDir(path)
     end
 
     local orig_changeToPath = FileChooser.changeToPath

--- a/modules/filebrowser/patches/context_menu.lua
+++ b/modules/filebrowser/patches/context_menu.lua
@@ -713,7 +713,7 @@ local function apply_context_menu()
             local home_dir = paths.getHomeDir()
             local cur_path = self_fc.path or ""
             if home_dir and not item._zen_collection_name and not item._zen_home_context then
-                if not paths.isInHomeDir(cur_path) then
+                if not paths.isInThemedDir(cur_path) then
                     return orig_showFileDialog(self_fc, item)
                 end
             end
@@ -2162,7 +2162,7 @@ local function apply_context_menu()
                 local home_dir_bh = paths.getHomeDir()
                 local cur_path_bh = fc.path or ""
                 if home_dir_bh then
-                    if not paths.isInHomeDir(cur_path_bh) then return false end
+                    if not paths.isInThemedDir(cur_path_bh) then return false end
                 end
                 local ffiUtil_bh = require("ffi/util")
                 local cur_real = ffiUtil_bh.realpath(cur_path_bh) or cur_path_bh

--- a/modules/filebrowser/patches/navbar.lua
+++ b/modules/filebrowser/patches/navbar.lua
@@ -90,6 +90,7 @@ local function apply_navbar()
     local config_default = {
         show_tabs = {
             books = true,
+            archive = false,
             manga = true,
             news = true,
             continue = true,
@@ -210,6 +211,11 @@ local function apply_navbar()
             id = "books",
             label = getBooksLabel(),
             icon = "library",
+        },
+        {
+            id = "archive",
+            label = _("Archive"),
+            icon = "quick_calibre",
         },
         {
             id = "manga",
@@ -482,6 +488,24 @@ local function apply_navbar()
         refreshLibraryStatusBar(fm)
     end
 
+    local function onTabArchive()
+        local fm = FileManager.instance
+        local archive_dir = paths.getArchiveDir()
+        if not (fm and fm.file_chooser and archive_dir) then return false end
+        if lfs.attributes(archive_dir, "mode") ~= "directory" then
+            local InfoMessage = require("ui/widget/infomessage")
+            UIManager:show(InfoMessage:new{
+                text = _("Archive folder not found: ") .. archive_dir,
+            })
+            return false
+        end
+        utils.closeWidgetsAbove(fm)
+        fm.file_chooser.path_items[archive_dir] = nil
+        fm.file_chooser:changeToPath(archive_dir)
+        refreshLibraryStatusBar(fm)
+        return true
+    end
+
     local function onTabManga()
         local fm = FileManager.instance
         if not fm then return end
@@ -698,6 +722,7 @@ local function apply_navbar()
 
     local tab_callbacks = {
         books = onTabBooks,
+        archive = onTabArchive,
         manga = onTabManga,
         news = onTabNews,
         continue = onTabContinue,
@@ -720,6 +745,7 @@ local function apply_navbar()
 
     local default_tab_whitelist = {
         books = true,
+        archive = true,
         manga = true,
         news = true,
         history = true,
@@ -734,6 +760,7 @@ local function apply_navbar()
 
     local active_tab_whitelist = {
         books = true,
+        archive = true,
         manga = true,
         news = true,
         authors = true,
@@ -1103,7 +1130,8 @@ local function apply_navbar()
     local function getVisibleTabs()
         local visible = {}
         for _i, id in ipairs(config.tab_order) do
-            if config.show_tabs[id] and tabs_by_id[id] then
+            local available = id ~= "archive" or paths.getArchiveDir() ~= nil
+            if available and config.show_tabs[id] and tabs_by_id[id] then
                 table.insert(visible, tabs_by_id[id])
                 if #visible >= navbar_max_tabs then break end
             end
@@ -1309,6 +1337,7 @@ local function apply_navbar()
                 refreshBackgroundTabChange()
                 -- Only repaint the FM navbar for tabs that render inside it (not overlay views)
                 local stays_in_browser = tapped_id == "books"
+                    or tapped_id == "archive"
                     or (tapped_id == "manga" and config.manga_action == "folder" and config.manga_folder ~= "")
                     or (tapped_id == "news" and config.news_action == "folder" and config.news_folder ~= "")
                 if stays_in_browser then
@@ -1513,6 +1542,16 @@ local function apply_navbar()
                 new_tab = "news"
             end
         end
+        -- Track the configured archive as its own persistent browser tab.
+        if not new_tab then
+            local archive_dir = paths.getArchiveDir()
+            local normalized_path = paths.normPath(path:gsub("/+$", ""))
+            if archive_dir
+                    and (normalized_path == archive_dir
+                        or startsWith(normalized_path, archive_dir .. "/")) then
+                new_tab = "archive"
+            end
+        end
         -- Check home dir for books
         if not new_tab then
             local home_dir = paths.getHomeDir()
@@ -1641,6 +1680,7 @@ local function apply_navbar()
                 syncActiveTabLabel()
                 refreshBackgroundTabChange()
                 local stays = tid == "books"
+                    or tid == "archive"
                     or (tid == "manga" and config.manga_action == "folder" and config.manga_folder ~= "")
                     or (tid == "news"  and config.news_action  == "folder" and config.news_folder  ~= "")
                 if stays then

--- a/modules/settings/sections/library_settings/navbar_settings.lua
+++ b/modules/settings/sections/library_settings/navbar_settings.lua
@@ -185,6 +185,13 @@ function M.build(ctx)
         { id = "page_right",  text = _("Next page")     },
         { id = "menu",        text = _("Menu")          },
     }
+    local archive_available = paths.getArchiveDir() ~= nil
+    if archive_available then
+        table.insert(navbar_tab_items, 2, {
+            id = "archive",
+            text = _("Archive"),
+        })
+    end
 
     if config.navbar.show_tabs.books == nil then
         config.navbar.show_tabs.books = true
@@ -204,6 +211,9 @@ function M.build(ctx)
         "books", "manga", "news", "history", "favorites",
         "collections", "authors", "series", "home", "tags", "to_be_read",
     }
+    if archive_available then
+        table.insert(default_tab_ids, 2, "archive")
+    end
 
     local function get_builtin_tab_label(tab_id)
         local tab = tab_item_by_id[tab_id]

--- a/spec/lua/unit/navbar_navigation_spec.lua
+++ b/spec/lua/unit/navbar_navigation_spec.lua
@@ -107,7 +107,10 @@ describe("file browser navbar navigation", function()
             resolveLocalIcon = function(_, icon) return icon end,
             closeWidgetsAbove = function() end,
         })
-        ZenSpec.replace("common/paths", { getHomeDir = function() return "/library" end })
+        ZenSpec.replace("common/paths", {
+            getHomeDir = function() return "/library" end,
+            getArchiveDir = function() return "/archive" end,
+        })
         ZenSpec.replace("common/plugin_root", "/plugin")
         ZenSpec.replace("common/shared_state", {
             get = function(_, key) return shared[key] end,
@@ -122,7 +125,9 @@ describe("file browser navbar navigation", function()
         })
         ZenSpec.replace("libs/libkoreader-lfs", {
             attributes = function(path, field)
-                if field == "mode" and path == "/library" then return "directory" end
+                if field == "mode" and (path == "/library" or path == "/archive") then
+                    return "directory"
+                end
             end,
             dir = function() return function() end end,
         })
@@ -136,13 +141,13 @@ describe("file browser navbar navigation", function()
                 features = { navbar = true, restore_library_view = false },
                 navbar = {
                     show_tabs = {
-                        books = true, home = true, authors = true, series = true,
+                        books = true, archive = true, home = true, authors = true, series = true,
                         tags = true, to_be_read = true, history = true,
                         favorites = true, collections = true, search = true,
                         page_left = true, page_right = true, menu = true,
                     },
                     tab_order = {
-                        "home", "books", "authors", "series", "tags", "to_be_read",
+                        "home", "books", "archive", "authors", "series", "tags", "to_be_read",
                         "history", "favorites", "collections", "search",
                         "page_left", "page_right", "menu",
                     },
@@ -191,10 +196,10 @@ describe("file browser navbar navigation", function()
     it("keeps configured tab order and resolves the first enabled default", function()
         assert.are.equal("home", _G.__ZEN_UI_NAVBAR_RESOLVE_DEFAULT_TAB())
         assert.are.same({
-            "home", "books", "authors", "series", "tags", "to_be_read",
+            "home", "books", "archive", "authors", "series", "tags", "to_be_read",
             "history", "favorites", "collections", "search",
             "page_left", "page_right", "menu",
-        }, { unpack(_G.__ZEN_UI_PLUGIN.config.navbar.tab_order, 1, 13) })
+        }, { unpack(_G.__ZEN_UI_PLUGIN.config.navbar.tab_order, 1, 14) })
         assert.are.equal("Home", _G.__ZEN_UI_ACTIVE_TAB_LABEL)
     end)
 
@@ -211,13 +216,13 @@ describe("file browser navbar navigation", function()
     it("dispatches books and stock file-browser tabs to their intended actions", function()
         make_instance()
         for _i, id in ipairs({
-            "books", "history", "favorites", "collections", "search",
+            "books", "archive", "history", "favorites", "collections", "search",
             "page_left", "page_right", "menu",
         }) do
             assert.is_true(_G.__ZEN_UI_NAVBAR_OPEN_TAB(id))
         end
         assert.are.same({
-            "books:/library", "history", "favorites", "collections", "search",
+            "books:/library", "books:/archive", "history", "favorites", "collections", "search",
             "previous", "next", "menu",
         }, calls)
         assert.are.equal("Collections", _G.__ZEN_UI_ACTIVE_TAB_LABEL)

--- a/spec/lua/unit/paths_spec.lua
+++ b/spec/lua/unit/paths_spec.lua
@@ -17,4 +17,15 @@ describe("paths", function()
         assert.is_false(Paths.isPrimaryHomeRoot("/library/extra"))
         assert.is_false(Paths.isInHomeDir("/outside/Book.epub"))
     end)
+
+    it("themes the external archive without treating it as a library root", function()
+        local original_get_archive_dir = Paths.getArchiveDir
+        Paths.getArchiveDir = function() return "/storage/emulated/0/Archive" end
+
+        assert.is_true(Paths.isInThemedDir("/sdcard/Archive/Book.epub"))
+        assert.is_false(Paths.isInHomeDir("/sdcard/Archive/Book.epub"))
+        assert.is_false(Paths.isHomeRoot("/sdcard/Archive"))
+
+        Paths.getArchiveDir = original_get_archive_dir
+    end)
 end)


### PR DESCRIPTION
## Summary

- detect the archive folder configured by the Move to Archive user patch
- apply Zen UI browser display styling and context menus inside that archive without treating it as a library root
- add an optional Archive Navbar tab that opens the configured folder
- only expose/show the Archive tab while an archive path is configured

Archived books remain excluded from Home widgets, library statistics, and library database scans.

## Testing

- tested on an Android device with a configured archive folder
- verified Archive appears in the Navbar tab picker, opens the configured folder, and tracks active state
- verified the archive uses Zen UI display styling and long-press menus
- Lua syntax and whitespace checks pass

The full automated suite was not run because the local KOReader test runtime is unavailable.