### PR TITLE
Open default tab on pressing physical home button

### DIFF
--- a/modules/filebrowser/patches/navbar.lua
+++ b/modules/filebrowser/patches/navbar.lua
@@ -1530,6 +1530,21 @@ local function apply_navbar()
         end
     end
 
+    -- === Physical Home button: return to the default navbar tab ===
+
+    local orig_onHome = FileManager.onHome
+
+    function FileManager:onHome()
+        if is_navbar_enabled() then
+            utils.closeWidgetsAbove(self)
+            open_default_tab()
+            return true
+        end
+        if orig_onHome then
+            return orig_onHome(self)
+        end
+    end
+
     -- Inject navbar into FM after all plugins finish init.
 
     local function resizeFileChooser(file_chooser, target_height)
@@ -2255,6 +2270,16 @@ local function apply_navbar()
                 if m.close_callback then m.close_callback()
                 elseif m.onClose then m:onClose()
                 else UIManager:close(m) end
+                return true
+            end
+
+            -- Physical Home button: close this standalone view and return to
+            -- the default navbar tab, same as pressing Home from the main FM.
+            menu.key_events.Home = { { "Home" } }
+            function menu:onHome()
+                _navbar_focused_idx = nil
+                closeStandaloneView(self)
+                open_default_tab()
                 return true
             end
         end

--- a/modules/global/global.lua
+++ b/modules/global/global.lua
@@ -7,6 +7,7 @@ local PATCH_MODULES = {
     brightness_schedule    = "modules/global/patches/brightness_schedule",
     menu_top_swipe         = "modules/global/patches/menu_top_swipe",
     opds                   = "modules/global/patches/opds",
+    cloud_storage_home     = "modules/global/patches/cloud_storage_home",
     kindle_network_profile_guard = "modules/global/patches/kindle_network_profile_guard",
     lockdown_mode          = "modules/global/patches/lockdown_mode",
     incognito_mode         = "modules/global/patches/incognito_mode",
@@ -63,6 +64,11 @@ function M.init(logger, plugin)
     local opds_fn = load_patch("opds")
     if opds_fn and plugin.config.features.zen_opds ~= false then
         run_patch(logger, plugin, "opds", opds_fn)
+    end
+
+    local cloud_storage_home_fn = load_patch("cloud_storage_home")
+    if cloud_storage_home_fn then
+        run_patch(logger, plugin, "cloud_storage_home", cloud_storage_home_fn)
     end
 
     local kindle_network_profile_guard_fn = load_patch("kindle_network_profile_guard")

--- a/modules/global/patches/cloud_storage_home.lua
+++ b/modules/global/patches/cloud_storage_home.lua
@@ -1,0 +1,35 @@
+-- Physical Home button support for KOReader's stock Cloud storage browser.
+-- CloudStorage doesn't register a Home key handler by default, so pressing
+-- Home there normally does nothing. Close the browser (regardless of folder
+-- depth) and return to the default navbar tab underneath, matching the
+-- behavior in the File Manager and other Zen UI library views.
+
+local function apply_cloud_storage_home()
+    local ok_cs, CloudStorage = pcall(require, "apps/cloudstorage/cloudstorage")
+    if not ok_cs or not CloudStorage then return end
+    if CloudStorage._zen_home_patched then return end
+    CloudStorage._zen_home_patched = true
+
+    local Device = require("device")
+    local UIManager = require("ui/uimanager")
+
+    local orig_init = CloudStorage.init
+    function CloudStorage:init()
+        orig_init(self)
+        if Device:hasKeys() then
+            self.key_events = self.key_events or {}
+            self.key_events.Home = { { "Home" } }
+        end
+    end
+
+    function CloudStorage:onHome()
+        UIManager:close(self)
+        local open_default = rawget(_G, "__ZEN_UI_NAVBAR_OPEN_DEFAULT_TAB")
+        if type(open_default) == "function" then
+            open_default()
+        end
+        return true
+    end
+end
+
+return apply_cloud_storage_home

--- a/modules/global/patches/opds.lua
+++ b/modules/global/patches/opds.lua
@@ -844,11 +844,28 @@ local function apply_opds()
                 { "Menu" },
                 event = "ZenOPDSMenu",
             }
+            -- Physical Home button: close the OPDS browser entirely (regardless
+            -- of catalog depth) and return to the default navbar tab underneath.
+            browser.key_events.Home = { { "Home" } }
         end
     end
 
     function OPDSBrowser:onZenOPDSMenu()
         activate_right_button(self)
+        return true
+    end
+
+    function OPDSBrowser:onHome()
+        if self.close_callback then
+            local ok = pcall(self.close_callback)
+            if not ok then UIManager:close(self) end
+        else
+            UIManager:close(self)
+        end
+        local open_default = rawget(_G, "__ZEN_UI_NAVBAR_OPEN_DEFAULT_TAB")
+        if type(open_default) == "function" then
+            open_default()
+        end
         return true
     end
 


### PR DESCRIPTION
When the physical home button is pressed, return to the currently configured default navbar tab (on devices with a physical home button).

Tested on a reMarkable 1.