### PR TITLE
Fix custom dispatcher buttons doing nothing in the reader

### DIFF
--- a/modules/menu/patches/quick_settings.lua
+++ b/modules/menu/patches/quick_settings.lua
@@ -1035,6 +1035,13 @@ local function apply_quick_settings()
                     callback = function(tm)
                         tm:closeMenu()
                         SettingsTransition.close()
+                        -- In the reader the touch menu sits above the bottom
+                        -- ConfigDialog. UIManager:sendEvent (which Dispatcher:execute
+                        -- uses for "none"-category actions) only reaches the topmost
+                        -- window, so with the ConfigDialog still open the dispatched
+                        -- event would be swallowed and never reach ReaderUI. Close it
+                        -- before dispatching.
+                        UIManager:broadcastEvent(Event:new("CloseConfigMenu"))
                         UIManager:nextTick(function()
                             if type(cb_action) == "table" and next(cb_action) then
                                 Dispatcher:execute(cb_action)


### PR DESCRIPTION
Super cool plugin - I use it together with Bookshelf and my own Tome plugin (a self-hosted library server with a KOReader companion). I ran into the following bug:

Custom quick-settings buttons bound to a dispatcher action work in the file browser but appear dead while reading a book: the panel closes and nothing happens.

Root cause: in the reader, the touch menu sits above the bottom ConfigDialog. The button callback closes the touch menu and then dispatches the action. For "none"-category actions, `Dispatcher:execute` delivers the event via `UIManager:sendEvent`, which only reaches the topmost window. After `closeMenu` the topmost window is the still-open ConfigDialog, which doesn't handle the event and doesn't propagate it down to ReaderUI - the action is silently swallowed. In the file browser there is no ConfigDialog, so the same button works there. Built-in buttons are unaffected because they call their targets directly instead of dispatching events. The existing one-tick deferral doesn't help, because nothing closes the ConfigDialog.

Fix: broadcast `CloseConfigMenu` before the deferred dispatch, so the action lands on the reader. This mirrors KOReader's own quickmenu, which closes its window before calling `Dispatcher:execute` (`Dispatcher._showAsMenu` in `frontend/dispatcher.lua`) - dispatcher actions assume the reader/file browser is the topmost window, which gesture- and key-triggered execution guarantees naturally.

This is not specific to any one plugin: with the ConfigDialog left open, KOReader's built-in actions (e.g. `history`) are swallowed the same way when dispatched from a custom button.

Verification:
- Reproduced on current `dev` (3.0.0) and on v2.5.4, on KOReader v2025.08 and master, in the desktop emulator and on a Kindle e-reader, with a custom button bound to a plugin-registered dispatcher action (`category = "none"`, `general = true`).
- With the fix, the same tap opens the plugin's menu from inside a book.
- `luacheck -q _meta.lua main.lua common config modules`: 0 warnings / 0 errors.
- `./spec/run lua`: 655 passed. `./spec/run smoke`: 655 + 8 passed (23 skipped, emulator-overlay opt-ins). `./spec/run package-check`: OK.