### PR TITLE
Fix "Read today" translation

### DIFF
--- a/locales/de.po
+++ b/locales/de.po
@@ -1792,7 +1792,7 @@ msgid "Read time"
 msgstr "Zeit lesen"
 
 msgid "Read today"
-msgstr "Lesen Sie noch heute"
+msgstr "Heute gelesen"
 
 msgid "Reader"
 msgstr "Lesemodus"


### PR DESCRIPTION
Since "Read today" means how long you have read today, the translation "Heute gelesen" fits better.