### PR TITLE
Exclude folders from library search results

### DIFF
--- a/modules/filebrowser/patches/search.lua
+++ b/modules/filebrowser/patches/search.lua
@@ -154,6 +154,7 @@ local function apply_search()
         if not is_enabled() then
             return orig_isFileMatch(self, filename, fullpath, search_string, is_file)
         end
+        if not is_file then return false end
         if search_string == "*" then
             return true
         end

--- a/spec/lua/unit/filebrowser_search_spec.lua
+++ b/spec/lua/unit/filebrowser_search_spec.lua
@@ -94,4 +94,18 @@ describe("file browser search", function()
         assert.is_true(closed == dialog)
         assert.are.equal(1, close_count)
     end)
+
+    it("matches books but not folders with the same search text", function()
+        local FileManagerFileSearcher = require("apps/filemanager/filemanagerfilesearcher")
+
+        assert.is_true(FileManagerFileSearcher:isFileMatch(
+            "Invincible Presents - Atom Eve 03.cbz",
+            "/library/Invincible Presents - Atom Eve 03.cbz",
+            "atom",
+            true))
+        assert.is_false(FileManagerFileSearcher:isFileMatch(
+            "Invincible Presents - Atom Eve & Rex Splode",
+            "/library/Invincible Presents - Atom Eve & Rex Splode",
+            "atom"))
+    end)
 end)


### PR DESCRIPTION
## Summary

- Restrict ZenOS library search results to book files.
- Add regression coverage for matching books and folders with the same search text.

## Reported problem

On a Kindle Colorsoft Signature Edition, searching the ZenOS library for `atom` returned several Invincible results.

Books previously read in KOReader opened normally from the search results. Results that appeared to be unread books returned to ZenOS Home instead of opening.

Reproduction steps:

1. Open ZenOS Home.
2. Select Search.
3. Search for `atom`.
4. Select a result that appears unread.
5. ZenOS returns to Home instead of opening the book.
6. Repeat the search and select a previously read result.
7. The previously read book opens normally.

## Root cause

ZenOS applied filename matching to both files and directories. An Invincible directory containing `Atom Eve & Rex Splode` appeared in the results and looked like an unread book. Selecting it followed folder navigation instead of opening a reader document, which exposed Home.

Previously read results worked because those entries were actual CBZ files.

## Fix

Library search now excludes directories and returns book files only.

## Testing

- LuaCheck: 0 warnings and 0 errors across 216 files.
- Focused file browser search specs: 3 successes.
- Verified on the affected Kindle Colorsoft with KOReader v2026.07.2.
- Searching for `atom` no longer shows the matching directories.
- An unread Atom CBZ opens successfully from the search results.

## Test limitation

The complete `./spec/run lua` command could not start because automatic KOReader runtime provisioning failed in KOReader's `make/gettext.mk`.